### PR TITLE
Testing tagging for integration and filtering of slow or unstable tests

### DIFF
--- a/java-library.gradle
+++ b/java-library.gradle
@@ -27,6 +27,37 @@ tasks.named('compileTestJava') {
     targetCompatibility = JavaVersion.toVersion(LANGUAGE_LEVEL)
 }
 
+tasks.withType(Test).configureEach {
+    useJUnitPlatform {
+        excludeTags 'slow', 'unstable'
+        if (project.hasProperty('includeTags')) {
+            Set<String> tags = (project.includeTags as String).split(',')
+            excludeTags.removeAll(tags)
+            includeTags.addAll(tags)
+        }
+        if (project.hasProperty('excludeTags')) {
+            Set<String> values = (project.excludeTags as String).split(',')
+            excludeTags.removeAll(values)
+            excludeTags.addAll(values)
+        }
+    }
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs integration tests tagged with "integration".'
+    group = 'verification'
+
+    useJUnitPlatform {
+        includeTags 'integration'
+    }
+
+    shouldRunAfter tasks.named('test')
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('integrationTest')
+}
+
 repositories {
     mavenCentral()
 }

--- a/java-test-library.gradle
+++ b/java-test-library.gradle
@@ -21,6 +21,12 @@ compileJava {
 tasks.withType(JavaCompile).configureEach {
     options.release.set(LANGUAGE_LEVEL)
 }
+tasks.withType(Test).configureEach {
+    useJUnitPlatform {
+        excludeTags 'integration', 'slow', 'unstable' // Excludes tests tagged with 'integration' or 'slow'
+    }
+}
+
 
 tasks.named('compileTestJava') {
     sourceCompatibility = JavaVersion.toVersion(LANGUAGE_LEVEL)


### PR DESCRIPTION
Testing tagging for integration and filtering of slow or unstable tests

1. Added new Gradle task 'integrationTest' for tests tagged 'integration'.
2. Added default test exclusion rules for 'slow' and 'unstable' tags
3. Added gradle command line flags 'excludeTags' and 'includeTags.  For example -PincludeTags=slow   

