### PR TITLE
Moved AutoClose from Contracts interface to implementation

### DIFF
--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Contracts.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Contracts.java
@@ -6,7 +6,7 @@ package io.github.jonloucks.contracts.api;
  * It does know how to load the default from contracts-impl.
  * However, the design is open to have it replaced with an alternative implementation.
  */
-public interface Contracts extends AutoOpen, AutoClose {
+public interface Contracts extends AutoOpen {
     
     /**
      * Claim the deliverable from a bound contract.

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ContractsImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ContractsImpl.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 import static io.github.jonloucks.contracts.api.Checks.*;
 import static java.util.Optional.ofNullable;
 
-final class ContractsImpl implements Contracts {
+final class ContractsImpl implements Contracts, AutoClose  {
 
     @Override
     public AutoClose open() {

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Decoy.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Decoy.java
@@ -2,7 +2,7 @@ package io.github.jonloucks.contracts.test;
 
 import io.github.jonloucks.contracts.api.*;
 
-public interface Decoy<D> extends Promisor<D>, ContractsFactory, Contracts, AutoOpen, AutoCloseable {
+public interface Decoy<D> extends Promisor<D>, ContractsFactory, Contracts, AutoOpen, AutoClose {
     @Override
     default AutoClose open() { return this;}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.github.jonloucks.contracts
-version=2.0.0
+version=2.0.1


### PR DESCRIPTION
Moved AutoClose from Contracts interface to implementation.

It was causing confusing warnings and it did not belong in the interface.