### PR TITLE
Standardized exception messages.

### DIFF
--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Checks.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Checks.java
@@ -10,7 +10,7 @@ public final class Checks {
      * Test coverage not possible, java module protections in place
      */
     private Checks() {
-        throw new AssertionError("Illegal constructor");
+        throw new AssertionError("Illegal constructor call.");
     }
     
     /**
@@ -22,7 +22,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> Contract<T> contractCheck(Contract<T> contract) {
-        return nullCheck(contract, "contract was not preset");
+        return nullCheck(contract, "Contract was not preset.");
     }
     
     /**
@@ -31,7 +31,7 @@ public final class Checks {
      * @return a valid Contracts
      */
     public static Contracts contractsCheck(Contracts contracts) {
-        return nullCheck(contracts, "contracts was not present");
+        return nullCheck(contracts, "Contracts must be present.");
     }
     
     /**
@@ -43,7 +43,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> Promisor<T> promisorCheck(Promisor<T> promisor) {
-        return nullCheck(promisor, "promisor was not preset");
+        return nullCheck(promisor, "Promisor was not preset.");
     }
     
     /**
@@ -55,7 +55,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T configCheck(T config) {
-        return nullCheck(config, "config was not preset");
+        return nullCheck(config, "Config was not preset.");
     }
     
     /**
@@ -67,7 +67,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T builderCheck(T builder) {
-        return nullCheck(builder, "builder was not present");
+        return nullCheck(builder, "Builder must be present.");
     }
     
     /**
@@ -79,7 +79,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T builderConsumerCheck(T builderConsumer) {
-        return nullCheck(builderConsumer, "builder consumer was not present");
+        return nullCheck(builderConsumer, "Builder consumer must be present.");
     }
     
     /**
@@ -91,7 +91,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T typeCheck(T type) {
-        return nullCheck(type, "type was was not present");
+        return nullCheck(type, "Type was must be present.");
     }
     
     /**
@@ -103,7 +103,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T nameCheck(T name) {
-        return nullCheck(name, "name was was not present");
+        return nullCheck(name, "Name was must be present.");
     }
     
     /**
@@ -115,7 +115,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T messageCheck(T t) {
-        return nullCheck(t, "Message was not present");
+        return nullCheck(t, "Message must be present.");
     }
     
     /**
@@ -143,7 +143,7 @@ public final class Checks {
      */
     public static <T> T illegalCheck(T t, boolean failed, String message) {
         if (null == message) {
-            throw new IllegalArgumentException("Message for illegal check was not present");
+            throw new IllegalArgumentException("Message for illegal check must be present.");
         }
         if (failed) {
             throw new IllegalArgumentException(message);
@@ -163,28 +163,28 @@ public final class Checks {
             final String deliverableValue = "validate value";
             
             if (validContracts.isBound(contract)) {
-                throw new ContractException("Contract should not be bound");
+                throw new ContractException("Contract should not be bound.");
             }
             final AutoClose bindReturn = validContracts.bind(contract, () -> deliverableValue);
             if (null == bindReturn) {
-                throw new ContractException("Contract bind returned null");
+                throw new ContractException("Contract bind returned null.");
             }
             try (AutoClose closeBinding = bindReturn) {
                 final AutoClose ignoredWarning = closeBinding;
                 if (!validContracts.isBound(contract)) {
-                    throw new ContractException("Contract should have been bound");
+                    throw new ContractException("Contract should have been bound.");
                 }
                 if (!deliverableValue.equals(validContracts.claim(contract))) {
-                    throw new ContractException("Contract claiming not working");
+                    throw new ContractException("Contract claiming not working.");
                 }
             }
             if (validContracts.isBound(contract)) {
-                throw new ContractException("Contract unbinding not working");
+                throw new ContractException("Contract unbinding not working.");
             }
         } catch (ContractException thrown) {
             throw thrown;
         } catch (RuntimeException thrown) {
-            throw new ContractException("Contracts unexpected validation error", thrown);
+            throw new ContractException("Contracts unexpected validation error.", thrown);
         }
     }
 }

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Checks.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Checks.java
@@ -22,7 +22,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> Contract<T> contractCheck(Contract<T> contract) {
-        return nullCheck(contract, "Contract was not preset.");
+        return nullCheck(contract, "Contract must be present.");
     }
     
     /**
@@ -43,7 +43,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> Promisor<T> promisorCheck(Promisor<T> promisor) {
-        return nullCheck(promisor, "Promisor was not preset.");
+        return nullCheck(promisor, "Promisor must be present.");
     }
     
     /**
@@ -55,7 +55,7 @@ public final class Checks {
      * @throws IllegalArgumentException when invalid
      */
     public static <T> T configCheck(T config) {
-        return nullCheck(config, "Config was not preset.");
+        return nullCheck(config, "Config must be present.");
     }
     
     /**

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Contract.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Contract.java
@@ -215,13 +215,13 @@ public final class Contract<T> {
     private Contract(Config<T> config) {
         this.config = configCheck(config);
         nameCheck(config.name());
-        nullCheck(config.typeName(), "config type was not present");
+        nullCheck(config.typeName(), "Config type must be present.");
     }
     
     //Since arrays are reified the following is safe and checked
     @SuppressWarnings("unchecked")
     private static <T> Class<T> detectDeliverableType(T ... reifiedArray) {
-        final T[] validReifiedArray = nullCheck(reifiedArray, "reified array was not present");
+        final T[] validReifiedArray = nullCheck(reifiedArray, "Reified array must be present.");
         return (Class<T>) validReifiedArray.getClass().getComponentType();
     }
 }

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/ContractBuilderImpl.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/ContractBuilderImpl.java
@@ -28,7 +28,7 @@ final class ContractBuilderImpl<T> implements Contract.Config.Builder<T> {
     
     @Override
     public Builder<T> typeName(String typeName) {
-        this.typeName = nullCheck(typeName, "typeName was not present");
+        this.typeName = nullCheck(typeName, "The typeName must be present");
         return this;
     }
     

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/ContractsFactoryFinder.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/ContractsFactoryFinder.java
@@ -32,7 +32,7 @@ final class ContractsFactoryFinder {
     }
     
     private Class<? extends ContractsFactory> getServivceFactoryClass() {
-        return nullCheck(config.serviceLoaderClass(), "config.serviceLoaderClass() was null");
+        return nullCheck(config.serviceLoaderClass(), "config.serviceLoaderClass() must be present.");
     }
     
     private Optional<ContractsFactory> createByReflection() {
@@ -51,7 +51,7 @@ final class ContractsFactoryFinder {
     }
     
     private String getClassName() {
-        return nullCheck(config.reflectionClassName(), "config.reflectionClassName() was null");
+        return nullCheck(config.reflectionClassName(), "config.reflectionClassName() must be present.");
     }
    
     private Constructor<?> getConstructor(String className) throws Throwable {
@@ -59,6 +59,6 @@ final class ContractsFactoryFinder {
     }
     
     private ContractException newNotFoundException() {
-        return new ContractException("Unable to find GlobalContracts ContractsFactory");
+        return new ContractException("Unable to find ContractsFactory.");
     }
 }

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ContractsImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ContractsImpl.java
@@ -177,19 +177,19 @@ final class ContractsImpl implements Contracts, AutoClose  {
     }
     
     private static ContractException newCloseDidNotCompleteException() {
-        return new ContractException("Contracts failed to close after trying multiple times");
+        return new ContractException("Contracts failed to close after trying multiple times.");
     }
     
     private static <T> ContractException newContractNotPromisedException(Contract<T> contract) {
-        return new ContractException("Contract " + contract + " was not promised");
+        return new ContractException("Contract " + contract + " was not promised.");
     }
     
     private static <T> ContractException newContractNotReplaceableException(Contract<T> contract) {
-        return new ContractException("Contract " + contract + " is not replaceable");
+        return new ContractException("Contract " + contract + " is not replaceable.");
     }
     
     private static <T> ContractException newContractDuplicateBindException(Contract<T> contract) {
-        return new ContractException("Contract " + contract + " duplicated bindings not allowed");
+        return new ContractException("Contract " + contract + " duplicated bindings not allowed.");
     }
     
     private final IdempotentImpl openState = new IdempotentImpl();

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ExtractPromisorImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ExtractPromisorImpl.java
@@ -30,7 +30,7 @@ final class ExtractPromisorImpl<T, R> implements Promisor<R> {
    
     ExtractPromisorImpl(Promisor<T> referent, Function<T, R> transform) {
         this.referent = promisorCheck(referent);
-        this.transform = nullCheck(transform, "transform was null");
+        this.transform = nullCheck(transform, "Transform must be present.");
     }
     
     private final Promisor<T> referent;

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/LifeCyclePromisorImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/LifeCyclePromisorImpl.java
@@ -53,7 +53,7 @@ final class LifeCyclePromisorImpl<T> implements Promisor<T> {
     
     private boolean getCurrentDeliverable(AtomicReference<T> placeholder) {
         if (usageCounter.get() == 0) {
-            throw new IllegalStateException("Usage count is zero");
+            throw new IllegalStateException("Usage count is zero.");
         }
         maybeRethrowOpenException();
         synchronized (simpleLock) {

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/RepositoryImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/RepositoryImpl.java
@@ -38,7 +38,7 @@ final class RepositoryImpl implements Repository, AutoClose {
         final Promisor<T> validPromisor = promisorCheck(promisor);
         
         if (storedContracts.containsKey(validContract)) {
-            throw new ContractException( "The contract " + validContract + " already promised");
+            throw new ContractException( "The contract " + validContract + "  is already promised.");
         }
         final StorageImpl<T> storage = new StorageImpl<>(contracts,validContract, validPromisor);
         
@@ -58,7 +58,7 @@ final class RepositoryImpl implements Repository, AutoClose {
     public void check() {
         requiredContracts.forEach(contract -> {
             if (!contracts.isBound(contract)) {
-                throw new ContractException( "The contract " + contract + " is required");
+                throw new ContractException( "The contract " + contract + " is required.");
             }
         });
     }

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ChecksTests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ChecksTests.java
@@ -155,10 +155,10 @@ public interface ChecksTests {
     @Test
     default void checks_illegalCheck_WhenFailed_Throws() {
         final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-            Checks.illegalCheck("abc", true, "xyz");
+            Checks.illegalCheck("abc", true, "Xyz.");
         });
         
-        Tools.assertThrown(thrown, "xyz");
+        assertThrown(thrown, "Xyz.");
     }
     @Test
     default void checks_illegalCheck_WhenNullMessage_Throws() {
@@ -166,6 +166,6 @@ public interface ChecksTests {
             Checks.illegalCheck("abc", false, null);
         });
         
-        Tools.assertThrown(thrown);
+        assertThrown(thrown);
     }
 }

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Decoy.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Decoy.java
@@ -32,6 +32,6 @@ public interface Decoy<D> extends Promisor<D>, ContractsFactory, Contracts, Auto
     
     @Override
     default Contracts create(Contracts.Config config) {
-        throw new ContractException("Decoy.create not implemented");
+        throw new ContractException("Decoy.create not implemented.");
     }
 }

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ExceptionTests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ExceptionTests.java
@@ -26,16 +26,16 @@ public interface ExceptionTests {
     
     @Test
     default void exception_ContractException_WithValid_Works() {
-        final ContractException exception = new ContractException("abc");
+        final ContractException exception = new ContractException("Abc.");
         
-        assertThrown(exception, "abc");
+        assertThrown(exception, "Abc.");
     }
     
     @Test
     default void exception_ContractException_WithCause_Works() {
-        final OutOfMemoryError cause = new OutOfMemoryError("memory");
-        final ContractException exception = new ContractException("abc", cause);
+        final OutOfMemoryError cause = new OutOfMemoryError("Out of memory.");
+        final ContractException exception = new ContractException("Abc.", cause);
         
-        assertThrown(exception, cause, "abc");
+        assertThrown(exception, cause, "Abc.");
     }
 }

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Tools.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Tools.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static io.github.jonloucks.contracts.api.Checks.*;
+import static java.lang.Character.isUpperCase;
 import static java.util.Optional.ofNullable;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,13 +22,14 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings("DataFlowIssue")
 public final class Tools {
     private Tools() {
-        throw new AssertionError("Illegal constructor");
+        throw new AssertionError("Illegal constructor call");
     }
     
     public static void assertFails(Executable executable) {
-        final Executable validExecutable = nullCheck(executable, "executable was null");
+        final Executable validExecutable = nullCheck(executable, "Executable must be present.");
         final AssertionError thrown = assertThrows(AssertionError.class, validExecutable);
-        assertThrown(thrown);
+        assertObject(thrown);
+        assertNotNull(thrown.getMessage());
     }
     /**
      * Assert that an object complies with basic expectations
@@ -41,8 +43,8 @@ public final class Tools {
         
         //noinspection SimplifiableAssertion,ConstantValue
         assertAll(
-            () -> assertEquals(object.hashCode(), object.hashCode(), "hash codes should not change."),
-            () -> assertNotNull(object.toString(), "object toString() was null."),
+            () -> assertEquals(object.hashCode(), object.hashCode(), "Hash codes should not change."),
+            () -> assertNotNull(object.toString(), "Object toString() was null."),
             () -> assertFalse(object.equals(null), "Object.equals(null) should be false."),
             () -> assertFalse(object.equals(unknown), "Object.equals(unknown) should be false.")
         );
@@ -73,26 +75,34 @@ public final class Tools {
         assertObject(thrown);
         
         assertAll(
+            () -> assertMessage(thrown.getMessage()),
             () -> assertEquals(cause, thrown.getCause(), "The cause should match."),
             () -> assertEquals(reason, thrown.getMessage(), "The reason should match."),
             () -> assertNotNull(thrown.toString(), "The string should not be null.")
         );
     }
     
+    public static void assertMessage(String message) {
+        assertNotNull(message, "Message must be present.");
+        assertFalse(message.isEmpty(), "Message should not be empty.");
+        assertTrue(isUpperCase(message.charAt(0)), "Message should start with a upper case character.");
+        assertEquals('.', message.charAt(message.length()-1), "Message should end with a dot: " + message + ".");
+    }
+    
     public static void assertThrown(Throwable thrown) {
-        assertNotNull(thrown, "thrown was null.");
+        assertNotNull(thrown, "Thrown must be present.");
         
         assertThrown(thrown, thrown.getCause(), thrown.getMessage());
     }
     
     public static void assertThrown(Throwable thrown, Throwable cause) {
-        assertNotNull(thrown, "thrown was null.");
+        assertNotNull(thrown, "Thrown must be present.");
         
         assertThrown(thrown, cause, thrown.getMessage());
     }
     
     public static void assertThrown(Throwable thrown, String reason) {
-        assertNotNull(thrown, "thrown was null.");
+        assertNotNull(thrown, "Thrown must be present.");
         
         assertThrown(thrown, thrown.getCause(), reason);
     }
@@ -109,8 +119,8 @@ public final class Tools {
 
         assertAll(
             () -> assertObject(contract),
-            () -> assertSame(config.cast(valid),contract.cast(valid), "cast valid value."),
-            () -> assertNull(contract.cast(null), "Cast null should return null."),
+            () -> assertSame(config.cast(valid),contract.cast(valid), "Casting a valid value should work."),
+            () -> assertNull(contract.cast(null), "Casting null should return null."),
             () -> assertThrows(ClassCastException.class, () -> contract.cast(System.class), "Invalid cast should thrown."),
             () -> assertSame(config.typeName(), contract.getTypeName(), "Contract type mismatch."),
             () -> assertSame(config.name(), contract.getName(), "Contract name mismatch."),
@@ -152,10 +162,10 @@ public final class Tools {
      * @param duration how long to sleep
      */
     public static void sleep(Duration duration) {
-        final Duration validDuration = nullCheck(duration, "Duration must not be null");
+        final Duration validDuration = nullCheck(duration, "Duration must be present.");
         final CountDownLatch latch = new CountDownLatch(1);
         
-        illegalCheck(validDuration, validDuration.isNegative(), "Duration must not be negative");
+        illegalCheck(validDuration, validDuration.isNegative(), "Duration must not be negative.");
         if (validDuration.isZero()) {
             return;
         }
@@ -180,15 +190,15 @@ public final class Tools {
     }
 
     public static void assertIsSerializable(Class<?> clazz) {
-        assertTrue(Serializable.class.isAssignableFrom(clazz), "Class must implement Serializable");
+        assertTrue(Serializable.class.isAssignableFrom(clazz), "Class must implement Serializable.");
         try {
             final Field serialVersionUIDField = clazz.getDeclaredField("serialVersionUID");
-            assertNotNull(serialVersionUIDField, "serialVersionUID field must exist");
-            assertTrue(Modifier.isStatic(serialVersionUIDField.getModifiers()), "serialVersionUID must be static");
-            assertTrue(Modifier.isFinal(serialVersionUIDField.getModifiers()), "serialVersionUID must be final");
-            assertEquals(long.class, serialVersionUIDField.getType(), "serialVersionUID must be of type long");
+            assertNotNull(serialVersionUIDField, "The serialVersionUID field must exist.");
+            assertTrue(Modifier.isStatic(serialVersionUIDField.getModifiers()), "The serialVersionUID must be static.");
+            assertTrue(Modifier.isFinal(serialVersionUIDField.getModifiers()), "The serialVersionUID must be final.");
+            assertEquals(long.class, serialVersionUIDField.getType(), "The serialVersionUID must be of type long.");
         }  catch (NoSuchFieldException ignored) {
-            fail("Unable to find serialVersionUID field in class " + clazz.getName());
+            fail("Unable to find serialVersionUID field in class " + clazz.getName() + ".");
         }
     }
     
@@ -204,7 +214,7 @@ public final class Tools {
     
     public static void withContracts(Contracts.Config config, Consumer<Contracts> block) {
         final Contracts.Config validConfig = configCheck(config);
-        final Consumer<Contracts> validBlock = nullCheck(block, "block was null");
+        final Consumer<Contracts> validBlock = nullCheck(block, "Block must be present.");
         final Contracts contracts = GlobalContracts.createContracts(validConfig);
         
         try (AutoClose closeContracts = contracts.open()) {

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ToolsTests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ToolsTests.java
@@ -66,12 +66,12 @@ public interface ToolsTests {
     
     @Test
     default void tools_assertThrown_Works() {
-        final String validReason = "reason";
-        final Throwable validCause = new RuntimeException("cause");
+        final String validReason = "This is a reason.";
+        final Throwable validCause = new RuntimeException("This is a cause.");
         final Throwable validException = new RuntimeException(validReason);
         final Throwable exceptionWithNullReason = new RuntimeException((String)null);
         final Throwable validExceptionWithCause = new RuntimeException(validReason, validCause);
-        final Throwable unknownException = new RuntimeException("unknown");
+        final Throwable unknownException = new RuntimeException("This is an unknown exception.");
    
         assertAll(
             () -> assertFails(() -> Tools.assertThrown(null, validCause, validReason)),
@@ -83,19 +83,19 @@ public interface ToolsTests {
             () -> assertFails(() -> Tools.assertThrown(exceptionWithNullReason, validCause, validReason)),
             () -> assertDoesNotThrow(() -> Tools.assertThrown(validException, null, validReason)),
             () -> assertFails(() -> Tools.assertThrown(validExceptionWithCause, null, validReason)),
-            () -> assertFails(() -> Tools.assertThrown(validExceptionWithCause, validCause, "different")),
+            () -> assertFails(() -> Tools.assertThrown(validExceptionWithCause, validCause, "Different.")),
             () -> assertDoesNotThrow(() -> Tools.assertThrown(validExceptionWithCause, validCause, validReason))
         );
     }
     
     @Test
     default void tools_assertThrownThrown_Works() {
-        final String validReason = "reason";
-        final Throwable validCause = new RuntimeException("cause");
+        final String validReason = "This is a reason.";
+        final Throwable validCause = new RuntimeException("This is a cause.");
         final Throwable validException = new RuntimeException(validReason);
         final Throwable exceptionWithNullReason = new RuntimeException((String)null);
         final Throwable validExceptionWithCause = new RuntimeException(validReason, validCause);
-        final Throwable unknownException = new RuntimeException("unknown");
+        final Throwable unknownException = new RuntimeException("This is an unknown exception.");
         
         assertAll(
             () -> assertFails(() -> Tools.assertThrown(null, validCause)),
@@ -180,7 +180,7 @@ public interface ToolsTests {
         final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, ()-> {
             Tools.sleep(null);
         });
-        assertThrown(thrown, "Duration must not be null");
+        assertThrown(thrown, "Duration must be present.");
     }
     
     @ParameterizedTest(name = "Duration {0} milliseconds")
@@ -205,6 +205,6 @@ public interface ToolsTests {
         final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
             Tools.sleep(expectedDuration);
         });
-        assertThrown(thrown, "Duration must not be negative");
+        assertThrown(thrown, "Duration must not be negative.");
     }
 }

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ValidateTests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/ValidateTests.java
@@ -44,7 +44,7 @@ public interface ValidateTests {
         final ContractException thrown = assertThrows(ContractException.class, () -> {
             Checks.validateContracts(contracts);
         });
-        assertThrown(thrown, "Contract should not be bound");
+        assertThrown(thrown, "Contract should not be bound.");
     }
     
     @Test
@@ -56,7 +56,7 @@ public interface ValidateTests {
         final ContractException thrown = assertThrows(ContractException.class, () -> {
             Checks.validateContracts(contracts);
         });
-        assertThrown(thrown, "Contract bind returned null");
+        assertThrown(thrown, "Contract bind returned null.");
     }
     
     @Test
@@ -69,7 +69,7 @@ public interface ValidateTests {
         final ContractException thrown = assertThrows(ContractException.class, () -> {
             Checks.validateContracts(contracts);
         });
-        assertThrown(thrown, "Contract should have been bound");
+        assertThrown(thrown, "Contract should have been bound.");
     }
     
     @Test
@@ -90,7 +90,7 @@ public interface ValidateTests {
         final ContractException thrown = assertThrows(ContractException.class, () -> {
             Checks.validateContracts(contracts);
         });
-        assertThrown(thrown, "Contract claiming not working");
+        assertThrown(thrown, "Contract claiming not working.");
     }
     
     @Test
@@ -105,13 +105,13 @@ public interface ValidateTests {
             return null;
         }).when(closeBinding).close();
         when(contracts.claim(any())).thenAnswer((Answer<?>) invocationOnMock -> {
-            throw new ArithmeticException("Math overflow");
+            throw new ArithmeticException("Math overflow.");
         });
         
         final ContractException thrown = assertThrows(ContractException.class, () -> {
             Checks.validateContracts(contracts);
         });
-        assertThrown(thrown, "Contracts unexpected validation error");
+        assertThrown(thrown, "Contracts unexpected validation error.");
     }
     
     @Test
@@ -156,6 +156,6 @@ public interface ValidateTests {
         final ContractException thrown = assertThrows(ContractException.class, () -> {
             Checks.validateContracts(contracts);
         });
-        assertThrown(thrown, "Contract unbinding not working");
+        assertThrown(thrown, "Contract unbinding not working.");
     }
 }


### PR DESCRIPTION
All exceptions now have standardized conventions.
Must start with a capital letter and end with a period.

Changed testing assertThrown(...) to validate messages comply with new standard.

For example. "something went wrong" is now "Something went wrong."