### PR TITLE
Removed AutoClose from some interfaces and fix some exception messages

### DIFF
--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/ContractsFactoryFinder.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/ContractsFactoryFinder.java
@@ -23,7 +23,7 @@ final class ContractsFactoryFinder {
     private Optional<? extends ContractsFactory> createByServiceLoader() {
         if (config.useServiceLoader()) {
             try {
-                return ServiceLoader.load(getServivceFactoryClass()).findFirst();
+                return ServiceLoader.load(getServiceFactoryClass()).findFirst();
             } catch (Throwable ignored) {
                 return Optional.empty();
             }
@@ -31,8 +31,8 @@ final class ContractsFactoryFinder {
         return Optional.empty();
     }
     
-    private Class<? extends ContractsFactory> getServivceFactoryClass() {
-        return nullCheck(config.serviceLoaderClass(), "config.serviceLoaderClass() must be present.");
+    private Class<? extends ContractsFactory> getServiceFactoryClass() {
+        return nullCheck(config.serviceLoaderClass(), "Contracts Service Loader class must be present.");
     }
     
     private Optional<ContractsFactory> createByReflection() {
@@ -51,7 +51,7 @@ final class ContractsFactoryFinder {
     }
     
     private String getClassName() {
-        return nullCheck(config.reflectionClassName(), "config.reflectionClassName() must be present.");
+        return nullCheck(config.reflectionClassName(), "Reflection reflection class name must be present.");
     }
    
     private Constructor<?> getConstructor(String className) throws Throwable {
@@ -59,6 +59,6 @@ final class ContractsFactoryFinder {
     }
     
     private ContractException newNotFoundException() {
-        return new ContractException("Unable to find ContractsFactory.");
+        return new ContractException("Unable to find Contracts factory.");
     }
 }

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/GlobalContracts.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/GlobalContracts.java
@@ -69,8 +69,8 @@ public final class GlobalContracts {
         final Contracts.Config validConfig = configCheck(config);
         
         final ContractsFactoryFinder factoryFinder = new ContractsFactoryFinder(config);
-        final ContractsFactory contractsFactory = nullCheck(factoryFinder.find(), "find() was null");
-        return nullCheck(contractsFactory.create(validConfig), "create() was null");
+        final ContractsFactory contractsFactory = nullCheck(factoryFinder.find(), "Contracts factory not found.");
+        return nullCheck(contractsFactory.create(validConfig), "Contracts could not be created.");
     }
     
     private static final GlobalContracts INSTANCE = new GlobalContracts();

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Repository.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Repository.java
@@ -8,7 +8,7 @@ import java.util.function.Supplier;
  * 1. Optional feature to register required contracts.
  * 2. Optional feature to manage multiple contract bindings.
  */
-public interface Repository extends AutoOpen, AutoClose {
+public interface Repository extends AutoOpen {
     
     /**
      * Contract to deliver a Repository factory

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/RepositoryImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/RepositoryImpl.java
@@ -12,24 +12,16 @@ import static java.util.Optional.ofNullable;
  * Implementation for {@link io.github.jonloucks.contracts.api.Repository}
  * @see io.github.jonloucks.contracts.api.Repository
  */
-final class RepositoryImpl implements Repository, AutoClose {
+final class RepositoryImpl implements Repository {
     
     @Override
     public AutoClose open() {
         if (openState.transitionToOpen()) {
             storedContracts.values().forEach(StorageImpl::bind);
             check();
-            return this;
+            return this::close;
         }
         return ()->{};
-    }
-    
-    @Override
-    public void close() {
-        if (openState.transitionToClosed()) {
-            storedContracts.values().forEach(StorageImpl::close);
-            storedContracts.clear();
-        }
     }
     
     @Override
@@ -72,6 +64,13 @@ final class RepositoryImpl implements Repository, AutoClose {
     
     RepositoryImpl(Contracts contracts) {
         this.contracts = contracts;
+    }
+    
+    private void close() {
+        if (openState.transitionToClosed()) {
+            storedContracts.values().forEach(StorageImpl::close);
+            storedContracts.clear();
+        }
     }
     
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.github.jonloucks.contracts
-version=2.1.0
+version=2.2.0


### PR DESCRIPTION
There were no functional problems fixed.

1. Removing AutoClose from Repository interface.  This is an implementation decision, not an API mandate.
2. Made implementation decision to make close() private.
3. Found some more places that did not follow exception message best practice.
