### PR TITLE
Added Repository.keep for use case where promisor has same life as Repository

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -60,14 +60,6 @@ jobs:
           name: jacoco-report
           path: main-project/build/reports/jacoco/test/html/
 
-      - name: Commit and Push the Badge
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actions
-          message: 'Update JaCoCo coverage badge'
-          add: 'jacoco-badge.svg'
-          cwd: badges
-
       - name: Generate JaCoCo Badge
         id: jacoco
         uses: cicirello/jacoco-badge-generator@v2.11.0

--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Repository.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Repository.java
@@ -27,6 +27,19 @@ public interface Repository extends AutoOpen {
     <T> AutoClose store(Contract<T> contract, Promisor<T> promisor);
     
     /**
+     * Keep the binding for the life of the repository
+     * If the Repository is not open, the binding will be created when repository is opened.
+     * If the Repository has already been opened the binding is created immediately
+     * @param contract the contract to be bound
+     * @param promisor the promisor to be bounded
+     * @param <T> the type of contract deliverable
+     */
+     default <T> void keep(Contract<T> contract, Promisor<T> promisor) {
+         //noinspection resource
+         store(contract, promisor);
+     }
+    
+    /**
      * Check that all requirements have fulfilled
      */
     void check();

--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ContractsImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/ContractsImpl.java
@@ -58,8 +58,8 @@ final class ContractsImpl implements Contracts {
         final Contracts.Config validConfig = configCheck(config);
         
         // keeping the promises open permanently
-        repository.store(Promisors.CONTRACT, PromisorsImpl::new);
-        repository.store(Repository.FACTORY, () -> () -> new RepositoryImpl(this));
+        repository.keep(Promisors.CONTRACT, PromisorsImpl::new);
+        repository.keep(Repository.FACTORY, () -> () -> new RepositoryImpl(this));
         
         if (validConfig.useShutdownHooks()) {
             Runtime.getRuntime().addShutdownHook(new Thread(this::close));

--- a/contracts-impl/src/main/java/module-info.java
+++ b/contracts-impl/src/main/java/module-info.java
@@ -1,6 +1,3 @@
-import io.github.jonloucks.contracts.api.ContractsFactory;
-import io.github.jonloucks.contracts.impl.ContractsFactoryImpl;
-
 /**
  * The implementation module for Contracts
  */
@@ -9,5 +6,5 @@ module io.github.jonloucks.contracts.impl {
     
     opens io.github.jonloucks.contracts.impl to io.github.jonloucks.contracts.api;
     
-    provides ContractsFactory with ContractsFactoryImpl;
+    provides io.github.jonloucks.contracts.api.ContractsFactory with io.github.jonloucks.contracts.impl.ContractsFactoryImpl;
 }

--- a/contracts-impl/src/test/java/module-info.java
+++ b/contracts-impl/src/test/java/module-info.java
@@ -1,5 +1,5 @@
 /**
- * contracts.impl tests
+ * contracts-impl tests
  */
 module io.github.jonloucks.contracts.impl.test {
     uses io.github.jonloucks.contracts.api.ContractsFactory;

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/RepositoryTests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/RepositoryTests.java
@@ -110,32 +110,29 @@ public interface RepositoryTests {
     }
     
     @Test
-    default void repository_store_Twice_Throws() {
+    default void repository_keep_Twice_Throws() {
         runWithScenario(( contracts,repository) -> {
             final Contract<String> textContract = Contract.create("test text");
             
-            try (AutoClose closeBinding = repository.store(textContract, () -> "x")) {
-                final AutoClose ignored = closeBinding;
-                
-                final ContractException thrown = assertThrows(ContractException.class, () -> {
-                    repository.store(textContract, () -> "y");
-                });
-                assertThrown(thrown);
-            }
+            repository.keep(textContract, () -> "x");
+            
+            final ContractException thrown = assertThrows(ContractException.class, () -> {
+                repository.keep(textContract, () -> "y");
+            });
+            assertThrown(thrown);
         });
     }
     
     @Test
-    default void repository_store_Replace_Works() {
+    default void repository_keep_Replace_Works() {
         runWithScenario(( contracts,repository) -> {
             final Contract<String> textContract = Contract.create(String.class, b -> b.replaceable(true));
+            
             try (AutoClose closeFirstBinding = contracts.bind(textContract, () -> "x") ) {
                 final AutoClose ignoredFirstBinding = closeFirstBinding;
-                try (AutoClose closeBinding = repository.store(textContract, () -> "y")) {
-                    final AutoClose ignored = closeBinding;
-                    final String text = contracts.claim(textContract);
-                    assertEquals("y", text, "contract deliverable replace should match");
-                }
+                repository.keep(textContract, () -> "y");
+                final String text = contracts.claim(textContract);
+                assertEquals("y", text, "contract deliverable replace should match");
             }
         });
     }

--- a/contracts-test/src/test/java/module-info.java
+++ b/contracts-test/src/test/java/module-info.java
@@ -1,8 +1,8 @@
+/**
+ * Module to run tests on test tools
+ */
 module io.github.jonloucks.contracts.test.run {
-    requires io.github.jonloucks.contracts.test;
-    requires org.junit.jupiter.api;
-    requires org.mockito.junit.jupiter;
-    
+    requires transitive io.github.jonloucks.contracts.test;
+
     exports io.github.jonloucks.contracts.test.run to org.junit.platform.commons;
-    
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.github.jonloucks.contracts
-version=2.2.1
+version=2.3.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit-version = "5.10.0"
 mockito-version = "[5.0,6.0)"
-gradle-kit-version = "[0.0.0,1.0.0)"
+gradle-kit-version = "[0.4.0,1.0.0)"
 
 [libraries]
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-version" }

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -1,15 +1,11 @@
-import io.github.jonloucks.contracts.api.ContractsFactory;
 
 module io.github.jonloucks.contracts.test.runtests {
     requires transitive io.github.jonloucks.contracts.test;
     requires transitive io.github.jonloucks.contracts.api;
     requires transitive io.github.jonloucks.contracts.impl;
     requires transitive io.github.jonloucks.contracts;
-    requires transitive org.junit.jupiter.api;
-    requires transitive org.mockito.junit.jupiter;
-    requires transitive org.mockito;
-    
-    uses ContractsFactory;
+
+    uses io.github.jonloucks.contracts.api.ContractsFactory;
 
     exports io.github.jonloucks.contracts.runtests to org.junit.platform.commons;
 }


### PR DESCRIPTION
Added Repository.keep for use case where promisor has same life as Repository

Removed unused step in Github release workflow
Normalized module definition files
Version 2.30