### PR TITLE
Disabling dependabot junit 6.0 which is not compatible with project requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - dependency-name: "org.junit.jupiter:*"
+    versions: [ ">=6.0.0" ]


### PR DESCRIPTION
Disabling dependabot junit 6.0 which is not compatible with project requirements