### PR TITLE
Fixes issue #69

### DIFF
--- a/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/LifeCyclePromisorImpl.java
+++ b/contracts-impl/src/main/java/io/github/jonloucks/contracts/impl/LifeCyclePromisorImpl.java
@@ -20,11 +20,13 @@ final class LifeCyclePromisorImpl<T> implements Promisor<T> {
     
     @Override
     public T demand() {
-        final AtomicReference<T> currentDeliverable = new AtomicReference<>();
-        if (getCurrentDeliverable(currentDeliverable)) {
-            return currentDeliverable.get();
+        synchronized (simpleLock) {
+            final AtomicReference<T> currentDeliverable = new AtomicReference<>();
+            if (getCurrentDeliverable(currentDeliverable)) {
+                return currentDeliverable.get();
+            }
+            return createDeliverableIfNeeded();
         }
-        return createDeliverableIfNeeded();
     }
     
     @Override
@@ -89,8 +91,8 @@ final class LifeCyclePromisorImpl<T> implements Promisor<T> {
         openException.set(null);
         final T currentDeliverable = referentPromisor.demand();
         atomicDeliverable.set(currentDeliverable);
-        openDeliverable(currentDeliverable);
         isDeliverableAcquired.set(true);
+        openDeliverable(currentDeliverable);
         return currentDeliverable;
     }
     

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Tools.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Tools.java
@@ -222,12 +222,16 @@ public final class Tools {
         final Contracts contracts = GlobalContracts.createContracts(validConfig);
         
         try (AutoClose closeContracts = contracts.open()) {
-            final AutoClose ignored = closeContracts;
+            ignore(closeContracts);
             validBlock.accept(contracts);
         }
     }
     
     public static void implicitClose(AutoClose close) {
         close.close();
+    }
+    
+    @SuppressWarnings("unused")
+    public static void ignore(Object instance) {
     }
 }


### PR DESCRIPTION
# Fixes issue #69
## Description
[Life Cycle Promisor has a reentrancy crash when open causes the same contract to be claimed](https://github.com/jonloucks/contracts/issues/69)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [ ] Chore (e.g., dependency updates, build tooling changes)

## How Has This Been Tested?

Added unit test to reproduce the problem

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes
