### PR TITLE
Feature: Aggregation of contracts, Fixes #78

### DIFF
--- a/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Contracts.java
+++ b/contracts-api/src/main/java/io/github/jonloucks/contracts/api/Contracts.java
@@ -1,5 +1,8 @@
 package io.github.jonloucks.contracts.api;
 
+import java.util.Collections;
+import java.util.List;
+
 import static io.github.jonloucks.contracts.api.BindStrategy.IF_ALLOWED;
 
 /**
@@ -18,6 +21,7 @@ public interface Contracts extends AutoOpen {
      * @return the value returned by the bound Promisor. A Promisor can return null
      * @throws ContractException if Promisor binding does not exist for the contract
      * @throws SecurityException if permission is denied
+     * @throws IllegalArgumentException may throw when an argument is null
      */
     <T> T claim(Contract<T> contract);
     
@@ -27,6 +31,7 @@ public interface Contracts extends AutoOpen {
      * @param contract the contract to check
      * @param <T>      The type of the value returned by the promisor
      * @return true iif bound
+     * @throws IllegalArgumentException may throw when an argument is null
      */
     <T> boolean isBound(Contract<T> contract);
     
@@ -39,6 +44,7 @@ public interface Contracts extends AutoOpen {
      * @return Use to release (unbind) this contract
      * @throws ContractException when contract is already bound and can't be replaced
      * @throws SecurityException when permission to bind is denied
+     * @throws IllegalArgumentException may throw when an argument is null
      */
     default <T> AutoClose bind(Contract<T> contract, Promisor<T> promisor) {
         return bind(contract, promisor, IF_ALLOWED);
@@ -52,8 +58,9 @@ public interface Contracts extends AutoOpen {
      * @param bindStrategy the binding strategy
      * @param <T>      The type of the value returned by the promisor
      * @return Use to release (unbind) this contract
-     * @throws ContractException when contract is already bound and can't be replaced
+     * @throws ContractException when contract is already bound, can't be replaced or not accepting bindings
      * @throws SecurityException when permission to bind is denied
+     * @throws IllegalArgumentException may throw when an argument is null
      */
     <T> AutoClose bind(Contract<T> contract, Promisor<T> promisor, BindStrategy bindStrategy);
     
@@ -61,6 +68,13 @@ public interface Contracts extends AutoOpen {
      * The Contracts configuration
      */
     interface Config {
+        
+        /**
+         * @return optional partners. Aggregated Contracts
+         */
+        default List<Contracts> getPartners() {
+            return Collections.emptyList();
+        }
         
         /**
          * @return if true, shutdown hooks will be added to ensure cleanup of Contracts

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/PartnersTests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/PartnersTests.java
@@ -1,0 +1,101 @@
+package io.github.jonloucks.contracts.test;
+
+import io.github.jonloucks.contracts.api.AutoClose;
+import io.github.jonloucks.contracts.api.Contract;
+import io.github.jonloucks.contracts.api.ContractException;
+import io.github.jonloucks.contracts.api.Contracts;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.github.jonloucks.contracts.test.Tools.*;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+public interface PartnersTests {
+    
+    @Test
+    default void partners_shadowPartners_Works() {
+        withContracts(partner -> {
+            final Contracts.Config config = new Contracts.Config() {
+                @Override
+                public List<Contracts> getPartners() {
+                    return singletonList(partner);
+                }
+            };
+            withContracts(config, primary -> {
+                final Contract<String> contract = Contract.create(String.class);
+                
+                try (AutoClose close1 = partner.bind(contract, () -> "Partner");
+                     AutoClose close2 = primary.bind(contract, () -> "Primary")) {
+                    ignore(close1);
+                    ignore(close2);
+                    
+                    assertEquals("Primary", primary.claim(contract));
+                }
+            });
+        });
+    }
+    
+    @Test
+    default void partners_unboundContracts_Works() {
+        withContracts(partner -> {
+            final Contracts.Config config = new Contracts.Config() {
+                @Override
+                public List<Contracts> getPartners() {
+                    return singletonList(partner);
+                }
+            };
+            withContracts(config, primary -> {
+                final Contract<String> contract = Contract.create(String.class);
+                
+                assertFalse(primary.isBound(contract));
+                assertThrown(assertThrows(ContractException.class, () -> primary.claim(contract)));
+            });
+        });
+    }
+    
+    @Test
+    default void partners_boundPartners_Works() {
+        withContracts(partner -> {
+            final Contracts.Config config = new Contracts.Config() {
+                @Override
+                public List<Contracts> getPartners() {
+                    return singletonList(partner);
+                }
+            };
+            withContracts(config, primary -> {
+                final Contract<String> contract = Contract.create(String.class);
+                
+                try (AutoClose close1 = partner.bind(contract, () -> "Partner")) {
+                    ignore(close1);
+                    
+                    assertTrue(primary.isBound(contract));
+                    assertEquals("Partner", primary.claim(contract));
+                }
+            });
+        });
+    }
+    
+    @Test
+    default void partners_boundPrimary_Works() {
+        withContracts(partner -> {
+            final Contracts.Config config = new Contracts.Config() {
+                @Override
+                public List<Contracts> getPartners() {
+                    return singletonList(partner);
+                }
+            };
+            withContracts(config, primary -> {
+                final Contract<String> contract = Contract.create(String.class);
+                
+                try (AutoClose close = primary.bind(contract, () -> "Primary")) {
+                    ignore(close);
+                    
+                    assertTrue(primary.isBound(contract));
+                    assertEquals("Primary", primary.claim(contract));
+                }
+            });
+        });
+    }
+}

--- a/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Tests.java
+++ b/contracts-test/src/main/java/io/github/jonloucks/contracts/test/Tests.java
@@ -11,6 +11,7 @@ public interface Tests extends
     GlobalContractsTests,
     ExceptionTests,
     RepositoryTests,
+    PartnersTests,
     PromisorsTests,
     ValidateTests
 {


### PR DESCRIPTION
# Feature: Aggregation of contracts, Fixes #78

## Description

Added new configuration option when creating a new Contracts
```
        default List<Contracts> getPartners() {
            return Collections.emptyList();
        }
```

If Partners are provided, they are used a backup if the newly created Contracts does not have a binding.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [ ] Chore (e.g., dependency updates, build tooling changes)

## How Has This Been Tested?

Added new tests PartnersTests.java

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes
