### PR TITLE
Working on badge name failure related to dependabot

### DIFF
--- a/.github/workflows/main-pull-request.yml
+++ b/.github/workflows/main-pull-request.yml
@@ -21,6 +21,14 @@ jobs:
       pages: write
 
     steps:
+    - name: Modify branch name
+      run: |
+        BRANCH_NAME="${{ github.head_ref || github.ref_name}}"
+        # Replace slashes with underscores
+        MODIFIED_BRANCH_NAME_SLASHS_REPLACED="${BRANCH_NAME//\//_}"
+        # Remove dashes
+        SIMPLE_BRANCH_NAME="${MODIFIED_BRANCH_NAME_SLASHS_REPLACED//-/}"
+        echo "SIMPLE_BRANCH_NAME=${SIMPLE_BRANCH_NAME}" >> $GITHUB_ENV
     - name: Checkout badges branch dedicated to storing badges only
       uses: actions/checkout@v4
       with:
@@ -61,7 +69,7 @@ jobs:
       id: jacoco
       uses: cicirello/jacoco-badge-generator@v2.11.0
       with:
-        coverage-badge-filename: ${{ github.head_ref }}-coverage.svg
+        coverage-badge-filename: ${{ env.SIMPLE_BRANCH_NAME }}-coverage.svg
         badges-directory: badges
         jacoco-csv-file: main-project/build/reports/jacoco/test/jacocoTestReport.csv
 


### PR DESCRIPTION
# Working on badge name failure related to dependabot

## Description

Working on badge name failure related to dependabot.
Pull request Github Workflow badge name logic did not support dependabot branch naming

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code improvement or restructuring without changing external behavior)
- [ ] Documentation update
- [x] Chore (e.g., dependency updates, build tooling changes)

## How Has This Been Tested?

All tests pass

## Checklist:

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if necessary).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Additional Notes
